### PR TITLE
chore: Add beautifulsoup into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pystyle
 requests
 tqdm
 contextlib3
+bs4
 gevent>=23.9.0
 numpy>=1.22.2
 setuptools>=65.5.1


### PR DESCRIPTION
Currently, making venv and installing using `requirements.txt`, running `proXXy.py` makes an error.
```bash
(venv) C:\Users\OWNER\Documents\_github\proXXy>pip install -r requirements.txt
Collecting hrequests
...
Successfully installed aioprocessing-2.0.1 anyio-4.0.0 async-class-0.5.0 certifi-2023.7.22 cffi-1.16.0 charset-normalizer-3.3.1 colorama-0.4.6 contextlib3-3.10.0 cssselect-1.2.0 exceptiongroup-1.1.3 gevent-23.9.1 greenlet-3.0.1 h11-0.14.0 hrequests-0.7.1 httpcore-0.18.0 httpx-0.25.0 idna-3.4 lxml-4.9.3 markdown-it-py-3.0.0 mdurl-0.1.2 msvc-runtime-14.34.31931 numpy-1.26.1 orjson-3.9.10 parse-1.19.1 pycparser-2.21 pygments-2.16.1 pyquery-2.0.0 pystyle-2.9 requests-2.31.0 rich-13.6.0 setuptools-68.2.2 sniffio-1.3.0 tqdm-4.66.1 urllib3-2.0.7 w3lib-2.1.2 zope.event-5.0 zope.interface-6.1


(venv) C:\Users\OWNER\Documents\_github\proXXy>python proXXy.py
Downloading Chrome version history...
Downloading Firefox version history...
Downloading tls-client library from bogdanfinn/tls-client...
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.8/16.8 MB 1.4 MB/s
WARNING: Please run `pip install hrequests[all]` for headless browsing support.
Traceback (most recent call last):
  File "C:\Users\OWNER\Documents\_github\proXXy\venv\lib\site-packages\lxml\html\soupparser.py", line 10, in <module>
    from bs4 import (
ModuleNotFoundError: No module named 'bs4'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\OWNER\Documents\_github\proXXy\proXXy.py", line 3, in <module>
    import hrequests
  File "C:\Users\OWNER\Documents\_github\proXXy\venv\lib\site-packages\hrequests\__init__.py", line 19, in <module>
    from .parser import HTML
  File "C:\Users\OWNER\Documents\_github\proXXy\venv\lib\site-packages\hrequests\parser.py", line 13, in <module>
    from lxml.html.soupparser import fromstring as soup_parse
  File "C:\Users\OWNER\Documents\_github\proXXy\venv\lib\site-packages\lxml\html\soupparser.py", line 15, in <module>
    from BeautifulSoup import (
ModuleNotFoundError: No module named 'BeautifulSoup'
```

It seems that `hrequests` calls `lxml`, and `lxml` calls `beautifulsoup4` internally. There are already having issue and resolved commit on `hrequest`, but not released yet so we cannot use it. So I just adding beautifulsoup4 library into `requirements.txt`.

Reference:
https://github.com/daijro/hrequests/issues/15
https://github.com/daijro/hrequests/commit/886ec254a0803cbab1b8901c9e1c19103b645705